### PR TITLE
Include the sourceLabel when an error occurs.

### DIFF
--- a/lib/copy-github-labels.js
+++ b/lib/copy-github-labels.js
@@ -54,10 +54,10 @@ module.exports = function (opts) {
         return cb(err);
       }
 
-      labels.forEach(function (label) {
+      labels.forEach(function (sourceLabel) {
         
-        var exclude = matches(label.name, options.excludes);
-        var explicitInclude = matches(label.name, options.includes);
+        var exclude = matches(sourceLabel.name, options.excludes);
+        var explicitInclude = matches(sourceLabel.name, options.includes);
         
         if (exclude && !explicitInclude) {
           return;
@@ -68,20 +68,20 @@ module.exports = function (opts) {
         
         // If dry run, just run callback and don't copy
         if(options.dryRun){
-          return cb(null, label);
+          return cb(null, sourceLabel);
         }
 
         // Create label in destination repository
         self.github.issues.createLabel({
           user: destinationRepository.user,
           repo: destinationRepository.repo,
-          name: label.name,
-          color: label.color
-        }, function (err, res) {
+          name: sourceLabel.name,
+          color: sourceLabel.color
+        }, function (err, newLabel) {
           if (err) {
-            return cb(err);
+            return cb(err, sourceLabel);
           }
-          return cb(null, res);
+          return cb(null, newLabel);
         });
 
       });


### PR DESCRIPTION
This will allow the caller to provide a meaningful message that includes the source label details.
