### PR TITLE
Updated documentation to correct auth syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ var copyGitHubLabels = require('copy-github-labels')();
 
 // Optionally use credentials
 copyGitHubLabels.authenticate({
+  type: 'oauth',
   token: 'your-github-token'
 });
 


### PR DESCRIPTION
When the example is used to run the code, the following error is encountered

```
Error: Invalid authentication type, must be 'basic', 'integration', or 'oauth'
```

The proposed change will include the additional authentication `type` specification